### PR TITLE
Feature/blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ In the other hand, private tags have to be deleted excepting a list of safe priv
 
 ## Deidentification profile
 
-It is possible to personnalize deidentification tool using deidentification profiles. A profile is defined by a _.tsv_ file in the folder _deidentification/config/profiles/._ This file references all the DICOM tags to keep during deidentification, even if this tag have to be deleted/modified according to DICOM deidentification standard.
+It is possible to personnalize deidentification tool using deidentification profiles. A profile is defined by a _.tsv_ file in the folder _deidentification/config/profiles/._ This file references actions to be done on DICOM tags. Actions are the same as defined in the DICOM standard ([De-identification Action Codes](https://dicom.nema.org/medical/dicom/current/output/html/part15.html#table_E.1-1a), ex: 'X' -> remove, 'K' -> keep).
+Those rules override rules defined in the DICOM standard.
 
 An exemple of deidentification profile :
 
-| Tag | Name |
-| :---: | :---: |
-| (0018,1060) | Trigger Time |
-| (0019,100C) | B Value |
+| Tag | Name | Action |
+| :---: | :---: | :---: |
+| (0008,0104) | Code Meaning | X |
+| (0018,1060) | Trigger Time | K |
+| (0019,100C) | B Value | K |
 | (0019,100A) | Number of slices |
 | (0019,101E) | Display field of view |
 | ... | ... |

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -48,7 +48,7 @@ def _load_config(config_profile, tags_to_keep, tags_to_delete, anonymous):
         if tags_to_keep:
             tags_config.update({k: {'action': 'K'} for k in tags_to_keep})
         if tags_to_delete:
-            tags_config.update({k: {'action': 'X'} for k in tags_to_delete})
+            tags_config.update({x: {'action': 'X'} for x in tags_to_delete})
     return tags_config
 
 

--- a/deidentification/config.py
+++ b/deidentification/config.py
@@ -33,13 +33,13 @@ def load_config_profile(profile: str, anonymous: bool = False):
         with open(profile_path, 'r') as tsv_file:
             tsv_reader = csv.reader(tsv_file, delimiter='\t')
             _ = next(tsv_reader)  # header
-            to_keep = []
-            to_delete = []
+            tags_profile = {}
             for d in tsv_reader:
-                if len(d) > 2 and d[2] == 'X':
-                    to_delete.append(tag_to_tuple(d[0]))
+                if len(d) <= 2:
+                    action = 'K'
                 else:
-                    to_keep.append(tag_to_tuple(d[0]))
+                    action = d[2]
+                tags_profile[tag_to_tuple(d[0])] = {'name': d[1], 'action': action}
     except ValueError as e:
         if anonymous:
             tag_load_error = 'Error occurs during config profile load.'
@@ -48,7 +48,7 @@ def load_config_profile(profile: str, anonymous: bool = False):
     if tag_load_error:
         raise DeidentificationError(tag_load_error)
 
-    return to_keep, to_delete
+    return tags_profile
     
     
 # /!\ Siemens VIDA and CSA header ?

--- a/deidentification/config.py
+++ b/deidentification/config.py
@@ -33,7 +33,13 @@ def load_config_profile(profile: str, anonymous: bool = False):
         with open(profile_path, 'r') as tsv_file:
             tsv_reader = csv.reader(tsv_file, delimiter='\t')
             _ = next(tsv_reader)  # header
-            data = [tag_to_tuple(d[0]) for d in tsv_reader]
+            to_keep = []
+            to_delete = []
+            for d in tsv_reader:
+                if len(d) > 2 and d[2] == 'X':
+                    to_delete.append(tag_to_tuple(d[0]))
+                else:
+                    to_keep.append(tag_to_tuple(d[0]))
     except ValueError as e:
         if anonymous:
             tag_load_error = 'Error occurs during config profile load.'
@@ -42,7 +48,7 @@ def load_config_profile(profile: str, anonymous: bool = False):
     if tag_load_error:
         raise DeidentificationError(tag_load_error)
 
-    return data
+    return to_keep, to_delete
     
     
 # /!\ Siemens VIDA and CSA header ?

--- a/deidentification/config/profiles/cati_collector.tsv
+++ b/deidentification/config/profiles/cati_collector.tsv
@@ -1,4 +1,4 @@
-Tags	Name	Delete
+Tags	Name	Action
 (0008,0020)	Study Date
 (0008,0031)	Series Time
 (0008,0032)	Acquisition Time

--- a/deidentification/config/profiles/cati_collector.tsv
+++ b/deidentification/config/profiles/cati_collector.tsv
@@ -1,4 +1,4 @@
-Tags	Name
+Tags	Name	Delete
 (0008,0020)	Study Date
 (0008,0031)	Series Time
 (0008,0032)	Acquisition Time
@@ -46,3 +46,4 @@ Tags	Name
 (2005,10A1)	Syncra Scan type (correction B1)
 (2005,10A9)	Unknown (Correction distorsions)
 (2005,1013)	Unknown
+(0040,0561)	Original Attributes Sequence	X

--- a/deidentification/config/profiles/data_sharing.tsv
+++ b/deidentification/config/profiles/data_sharing.tsv
@@ -1,4 +1,4 @@
-Tags	Name	Delete
+Tags	Name	Action
 (0018,1060)	Trigger Time
 (0019,100C)	B Value
 (0019,100A)	Number of slices

--- a/deidentification/config/profiles/data_sharing.tsv
+++ b/deidentification/config/profiles/data_sharing.tsv
@@ -1,4 +1,4 @@
-Tags	Name
+Tags	Name	Delete
 (0018,1060)	Trigger Time
 (0019,100C)	B Value
 (0019,100A)	Number of slices
@@ -40,3 +40,4 @@ Tags	Name
 (2005,10A1)	Syncra Scan type (correction B1)
 (2005,10A9)	Unknown (Correction distorsions)
 (2005,1013)	Unknown
+(0040,0561)	Original Attributes Sequence	X

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -81,9 +81,12 @@ def test_anonymizer_public_tags(dicom_path):
 
 def test_anonymizer_input_tags(dicom_path):
     from deidentification import anonymizer
+    tags_config = {
+        (0x0008, 0x0032): {'action': 'K'},  # Usually deleted
+        (0x0008, 0x0008): {'action': 'X'}  # Usually kept
+    }
     a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
-                              tags_to_keep=[(0x0008, 0x0032)],  # Usually deleted
-                              tags_to_delete=[(0x0008, 0x0008)])  # Usually kept
+                              tags_config=tags_config)  # Usually kept
     a.run_ano()
     ds = pydicom.read_file(path_ano(dicom_path))
     assert not ds.get((0x0008, 0x0008))
@@ -102,9 +105,9 @@ def test_anonymizer_private_tags(dicom_path):
 def test_anonymizer_data_sharing_profile(dicom_path):
     from deidentification import anonymizer
     from deidentification.config import load_config_profile
-    tags_to_keep, tags_to_delete = load_config_profile('data_sharing')
+    tags_config = load_config_profile('data_sharing')
     a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
-                              tags_to_keep=tags_to_keep)
+                              tags_config=tags_config)
     a.run_ano()
     _ds = pydicom.read_file(dicom_path)
     assert _ds.get((0x2005, 0x101D))

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -79,6 +79,17 @@ def test_anonymizer_public_tags(dicom_path):
     assert not ds.get((0x0008, 0x0032))
 
 
+def test_anonymizer_input_tags(dicom_path):
+    from deidentification import anonymizer
+    a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
+                              tags_to_keep=[(0x0008, 0x0032)],  # Usually deleted
+                              tags_to_delete=[(0x0008, 0x0008)])  # Usually kept
+    a.run_ano()
+    ds = pydicom.read_file(path_ano(dicom_path))
+    assert not ds.get((0x0008, 0x0008))
+    assert ds.get((0x0008, 0x0032))
+
+
 def test_anonymizer_private_tags(dicom_path):
     from deidentification import anonymizer
     a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path))

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -91,10 +91,12 @@ def test_anonymizer_private_tags(dicom_path):
 def test_anonymizer_data_sharing_profile(dicom_path):
     from deidentification import anonymizer
     from deidentification.config import load_config_profile
-    tags_to_keep = load_config_profile('data_sharing')
+    tags_to_keep, tags_to_delete = load_config_profile('data_sharing')
     a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
                               tags_to_keep=tags_to_keep)
     a.run_ano()
+    _ds = pydicom.read_file(dicom_path)
+    assert _ds.get((0x2005, 0x101D))
     ds = pydicom.read_file(path_ano(dicom_path))
     assert ds.get((0x2005, 0x101D))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,10 +12,10 @@ def test_tag_lists():
 def test_anonymizer_profile_load():
     from deidentification.config import load_config_profile
     from deidentification import DeidentificationError
-    tags_to_keep = load_config_profile('data_sharing')
+    tags_to_keep, tags_to_delete = load_config_profile('data_sharing')
     assert isinstance(tags_to_keep, list)
     with pytest.raises(DeidentificationError, match=r"Profile .* does not exists."):
-        tags_to_keep = load_config_profile('wrong_profile')
+        tags_to_keep, tags_to_delete = load_config_profile('wrong_profile')
 
 
 def test_tag_to_tuple():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,10 +12,10 @@ def test_tag_lists():
 def test_anonymizer_profile_load():
     from deidentification.config import load_config_profile
     from deidentification import DeidentificationError
-    tags_to_keep, tags_to_delete = load_config_profile('data_sharing')
-    assert isinstance(tags_to_keep, list)
+    tags_config = load_config_profile('data_sharing')
+    assert isinstance(tags_config, dict)
     with pytest.raises(DeidentificationError, match=r"Profile .* does not exists."):
-        tags_to_keep, tags_to_delete = load_config_profile('wrong_profile')
+        tags_config = load_config_profile('wrong_profile')
 
 
 def test_tag_to_tuple():


### PR DESCRIPTION
The configuration file allows only to list tags that we want to keep during deidentification. It may be useful to have also the possibility to remove unwanted dicom tags in the header too.
To avoid multiply configuration files, I added the functionality in the same configuration file as tags to keep, as a new column.

Now it is possible to define "action" that could be made on tags, in a configuration file. Those actions are the same as used in the standard DICOM to deidentify public tags ([as here](https://dicom.nema.org/medical/dicom/current/output/html/part15.html#table_E.1-1a)).
