### PR TITLE
Config safe private

### DIFF
--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -434,8 +434,14 @@ class Anonymizer():
                 del ds[data_element.tag]
                 return
             private_creator_value = private_creator.value
-            # Check if the private creator is in the safe private attribute
-            # keys
+            private_creator_tag = (private_creator.tag.group, private_creator.tag.element)
+            # Check if private creator in tag_config
+            if (self._tags_config is not None
+                    and private_creator_tag in self._tags_config
+                    and private_creator.value == self._tags_config[private_creator_tag]['name']):
+                self._apply_action(ds, data_element, self._tags_config[private_creator_tag]['action'])
+                return
+            # Check if the private creator is in the safe private attribute keys
             if private_creator_value not in list(tag_lists.safe_private_attributes.keys()):
                 self.originalDict[data_element.tag] = data_element.value
                 del ds[data_element.tag]

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -172,6 +172,37 @@ def test_anonymize_anonymous(file_path):
         anonymize(file_path, path_ano(file_path), anonymous=True)
         
 
+def test_anonymize_config_safe_private(dicom_path):
+    from deidentification.anonymizer import Anonymizer
+    if not os.path.exists(OUTPUT_DIR):
+        os.makedirs(OUTPUT_DIR)
+    ds = pydicom.read_file(dicom_path)
+    tags_config = {
+        # Private Creator tag to be kept
+        (0x2005, 0x0011): {
+            'name': ds.get((0x2005, 0x0011)).value,
+            'action': 'K'
+        },
+        # Private Creator tag with wrong name
+        (0x2005, 0x0012): {
+            'name': 'XX',
+            'action': 'K'
+        }
+    }
+    output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
+    anon = Anonymizer(os.path.abspath(dicom_path),
+                      os.path.abspath(output_dicom_path),
+                      tags_config)
+    anon.run_ano()
+    
+    ds = pydicom.read_file(output_dicom_path)
+    
+    assert ds.get((0x2005, 0x0011))
+    assert ds.get((0x2005, 0x1199)) and ds.get((0x2005, 0x1134))
+    assert ds.get((0x2005, 0x0012))
+    assert not ds.get((0x2005, 0x1213))
+        
+
 # Anonymize bin
 
 def test_deidentification_bin(dicom_path):


### PR DESCRIPTION
It will be possible to specify Private Creator Tags in config profiles, with a specific value to check. In this case, the action is then applied to all tags that depend on that Private Creator Tag.
Example of line in config profile :

| Tags                | Name                                      | Action |
| --- | --- | --- |
| (2005, 0011)   | Philips MR Imaging DD 002    | K |