### PR TITLE
Private creator check

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,23 @@ In the other hand, private tags have to be deleted excepting a list of safe priv
 ## Deidentification profile
 
 It is possible to personnalize deidentification tool using deidentification profiles. A profile is defined by a _.tsv_ file in the folder _deidentification/config/profiles/._ This file references actions to be done on DICOM tags. Actions are the same as defined in the DICOM standard ([De-identification Action Codes](https://dicom.nema.org/medical/dicom/current/output/html/part15.html#table_E.1-1a), ex: 'X' -> remove, 'K' -> keep).
+
+In case of private tag, it is **highly recommended** to add the corresponding private creator value, which will be checked during deidentification. (To learn more about private creator tags: [Private Data Elements](https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.8.html))
+
+If tag referenced in profile corresponds to a private creator tag (with its value in *private creator* column), deidentification will keep all the block of element corresponding.
+
 Those rules override rules defined in the DICOM standard.
 
 An exemple of deidentification profile :
 
-| Tag | Name | Action |
-| :---: | :---: | :---: |
-| (0008,0104) | Code Meaning | X |
-| (0018,1060) | Trigger Time | K |
-| (0019,100C) | B Value | K |
-| (0019,100A) | Number of slices |
-| (0019,101E) | Display field of view |
-| ... | ... |
+| Tag | Name | Action | Private Creator |
+| :---: | :---: | :---: | :---: |
+| (0008,0104) | Code Meaning | X | |
+| (0018,1060) | Trigger Time | K | |
+| (0019,100C) | B Value | K | SIEMENS MR HEADER |
+| (0019,100A) | Number of slices | K | SIEMENS MR HEADER |
+| (0019,101E) | Display field of view | K | GEMS_ACQU_01 |
+| ... | ... | ... | ... |
 
 Two deidentification profiles are already defined in deidentification module.
 
@@ -86,13 +91,13 @@ Launch anon_example.py function to anonymize a dicom file.
 Whitout subject id (set as "Unknown" by default):
 
 ```sh
-python bin/deidentification -in myInputFolder -out myOutputFolder
+deidentification -in myInputFolder -out myOutputFolder
 ```
 
 With a subject id and configuration profile:
 
 ```sh
-python bin/deidentification -in myInputFolder -out myOutputFolder -id 0001XXXX -c data_sharing
+deidentification -in myInputFolder -out myOutputFolder -id 0001XXXX -c data_sharing
 ```
 
 ### Using python module

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -542,7 +542,7 @@ class Anonymizer():
         Gets the private creator tag of data_element.
         """
         if self._is_private_creator(data_element.tag.group, data_element.tag.element):
-            return data_element
+            return data_element.tag
         group = data_element.tag.group
         element = (data_element.tag.element & 0xff00) >> 8
         return pydicom.tag.Tag(group, element)

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -414,6 +414,13 @@ class Anonymizer():
             return
         # Check if the data element has to be kept
         if self._tags_config is not None and tag in self._tags_config:
+            # In case of private tag, check if private creator and check its value
+            if data_element.tag.is_private and self._tags_config[tag].get('private_creator'):
+                private_creator = ds.get(self._get_private_creator_tag(data_element), None)
+                if not private_creator.value or private_creator.value != self._tags_config[tag].get('private_creator'):
+                    del ds[data_element.tag]
+                    return
+            
             action = self._tags_config[tag]['action']
             self._apply_action(ds, data_element, action)
             return
@@ -526,6 +533,8 @@ class Anonymizer():
         """
         Gets the private creator tag of data_element.
         """
+        if self._is_private_creator(data_element.tag.group, data_element.tag.element):
+            return data_element
         group = data_element.tag.group
         element = (data_element.tag.element & 0xff00) >> 8
         return pydicom.tag.Tag(group, element)

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -415,7 +415,9 @@ class Anonymizer():
         # Check if the data element has to be kept
         if self._tags_config is not None and tag in self._tags_config:
             # In case of private tag, check if private creator and check its value
-            if data_element.tag.is_private and self._tags_config[tag].get('private_creator'):
+            if (data_element.tag.is_private
+                    and self._tags_config[tag].get('private_creator')
+                    and not self._is_private_creator(data_element.tag.group, data_element.tag.element)):
                 private_creator = ds.get(self._get_private_creator_tag(data_element), None)
                 if not private_creator.value or private_creator.value != self._tags_config[tag].get('private_creator'):
                     del ds[data_element.tag]
@@ -445,7 +447,7 @@ class Anonymizer():
             # Check if private creator in tag_config
             if (self._tags_config is not None
                     and private_creator_tag in self._tags_config
-                    and private_creator.value == self._tags_config[private_creator_tag]['name']):
+                    and private_creator.value == self._tags_config[private_creator_tag]['private_creator']):
                 self._apply_action(ds, data_element, self._tags_config[private_creator_tag]['action'])
                 return
             # Check if the private creator is in the safe private attribute keys

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -412,6 +412,7 @@ class Anonymizer():
             data_element.value = self._forced_values[tag]
             self.outputDict[data_element.tag] = self._forced_values[tag]
             return
+
         # Check if the data element has to be kept
         if self._tags_config is not None and tag in self._tags_config:
             do_apply_action = True
@@ -422,7 +423,6 @@ class Anonymizer():
                 private_creator = ds.get(self._get_private_creator_tag(data_element), None)
                 if not private_creator.value or private_creator.value != self._tags_config[tag].get('private_creator'):
                     do_apply_action = False
-            
             if do_apply_action:
                 action = self._tags_config[tag]['action']
                 self._apply_action(ds, data_element, action)

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -414,15 +414,16 @@ class Anonymizer():
             return
         # Check if the data element has to be kept
         if self._tags_config is not None and tag in self._tags_config:
-            skip = False
+            do_apply_action = True
             # In case of private tag, check if private creator and check its value
             if (data_element.tag.is_private
                     and self._tags_config[tag].get('private_creator')
                     and not self._is_private_creator(data_element.tag.group, data_element.tag.element)):
                 private_creator = ds.get(self._get_private_creator_tag(data_element), None)
                 if not private_creator.value or private_creator.value != self._tags_config[tag].get('private_creator'):
-                    skip = True
-            if not skip:
+                    do_apply_action = False
+            
+            if do_apply_action:
                 action = self._tags_config[tag]['action']
                 self._apply_action(ds, data_element, action)
                 return

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -414,18 +414,18 @@ class Anonymizer():
             return
         # Check if the data element has to be kept
         if self._tags_config is not None and tag in self._tags_config:
+            skip = False
             # In case of private tag, check if private creator and check its value
             if (data_element.tag.is_private
                     and self._tags_config[tag].get('private_creator')
                     and not self._is_private_creator(data_element.tag.group, data_element.tag.element)):
                 private_creator = ds.get(self._get_private_creator_tag(data_element), None)
                 if not private_creator.value or private_creator.value != self._tags_config[tag].get('private_creator'):
-                    del ds[data_element.tag]
-                    return
-            
-            action = self._tags_config[tag]['action']
-            self._apply_action(ds, data_element, action)
-            return
+                    skip = True
+            if not skip:
+                action = self._tags_config[tag]['action']
+                self._apply_action(ds, data_element, action)
+                return
         
         # Check if the data element is in the DICOM part 15/annex E tag list
         action = self._find_in_conf_profile(group, element)

--- a/deidentification/config.py
+++ b/deidentification/config.py
@@ -43,6 +43,8 @@ def load_config_profile(profile: str, anonymous: bool = False):
                 else:
                     action = d[2]
                 tags_profile[tag_to_tuple(d[0])] = {'name': d[1], 'action': action}
+                if len(d) > 3:
+                    tags_profile[tag_to_tuple(d[0])].update({'private_creator': d[3]})
     except ValueError as e:
         if anonymous:
             tag_load_error = 'Error occurs during config profile load.'

--- a/deidentification/config/profiles/cati_collector.tsv
+++ b/deidentification/config/profiles/cati_collector.tsv
@@ -5,7 +5,7 @@ Tags	Name	Action	Private Creator
 (0008,0033)	Content Time	K	
 (0008,103E)	Series Description	K	
 (0010,0010)	Patient's Name	K	
-(0018,1060)	Trigger Time	K	
+(0019,0010)	Private Creator	K	GEMS_ACQU_01
 (0019,100C)	B Value	K	SIEMENS MR HEADER
 (0019,100A)	Number of slices	K	SIEMENS MR HEADER
 (0019,101E)	Display field of view	K	GEMS_ACQU_01
@@ -16,19 +16,22 @@ Tags	Name	Action	Private Creator
 (0019,10BB)	User data 20	K	GEMS_ACQU_01
 (0019,10BC)	User data 21	K	GEMS_ACQU_01
 (0019,10BD)	User data 22	K	GEMS_ACQU_01
-(0021,1009)	Parallel acquisition	K	
+(0021,0010)	Private Creator	K	SIEMENS MR SDS 01
+(0021,0011)	Private Creator	K	SIEMENS MR SDS 01
+(0021,1009)	Parallel acquisition	K	SIEMENS MR SDS 01
 (0021,105A)	Diffusion direction	K	GEMS_RELA_01
 (0021,105E)	RTIA timer	K	GEMS_RELA_01
-(0021,114f)	Coil information	K	
-(0021,1156)	Parallel acquisition	K	
-(0021,1175)	Acquisition type	K	
-(0021,1176)	Correction information	K	
-(0021,1177)	Sequence information	K	
-(0021,1178)	Distorsion correction	K	
-(0021,1179)	Distorsion correction	K	
+(0021,114f)	Coil information	K	SIEMENS MR SDI 02
+(0021,1156)	Parallel acquisition	K	SIEMENS MR SDI 02
+(0021,1175)	Acquisition type	K	SIEMENS MR SDI 02
+(0021,1176)	Correction information	K	SIEMENS MR SDI 02
+(0021,1177)	Sequence information	K	SIEMENS MR SDI 02
+(0021,1178)	Distorsion correction	K	SIEMENS MR SDI 02
+(0021,1179)	Distorsion correction	K	SIEMENS MR SDI 02
 (0025,1007)	Images in Series (Number of slices)	K	GEMS_SERS_01
 (0025,101B)	Protocol Data Block (compressed)	K	GEMS_SERS_01
 (0027,1060)	Image dimension - X	K	GEMS_IMAG_01
+(0027,1062)	Number of Excitations		GEMS_IMAG_01
 (0043,102A)	User defined data	K	GEMS_PARM_01
 (0043,102C)	Effective echo spacing	K	GEMS_PARM_01
 (0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	GEMS_PARM_01
@@ -45,15 +48,25 @@ Tags	Name	Action	Private Creator
 (2001,1013)	EPI Factor	K	Philips Imaging DD 001
 (2001,1014)	Number of echoes	K	Philips Imaging DD 001
 (2001,1018)	Number of slices MR	K	Philips Imaging DD 001
-(2001,1020)	Scanning Technique Description MR	K	
+(2001,1020)	Scanning Technique Description MR	K	Philips Imaging DD 001
 (2001,101B)	Prepulse Delay	K	Philips Imaging DD 001
 (2001,1081)	Number of dynamic scans (Time points)	K	Philips Imaging DD 001
+(2005,0010)	Private Creator	K	Philips MR Imaging DD 001
 (2005,101D)	Unknown (Reconstruction matrix)	K	Philips MR Imaging DD 001
+(2005,1030)	Spectro Repetition Time	K	Philips MR Imaging DD 001
+(2005,1057)	Spectro voxel dim 1	K	Philips MR Imaging DD 001
+(2005,1058)	Spectro voxel dim 2	K	Philips MR Imaging DD 001
+(2005,1059)	Spectro voxel dim 3	K	Philips MR Imaging DD 001
+(2005,105a)	Spectro voxel coordinate 1	K	Philips MR Imaging DD 001
+(2005,105b)	Spectro voxel coordinate 2	K	Philips MR Imaging DD 001
+(2005,105c)	Spectro voxel coordinate 3	K	Philips MR Imaging DD 001
 (2005,1074)	Unknown	K	Philips MR Imaging DD 001
 (2005,1075)	Unknown	K	Philips MR Imaging DD 001
 (2005,1076)	Unknown	K	Philips MR Imaging DD 001
 (2005,10A1)	Syncra Scan type (correction B1)	K	Philips MR Imaging DD 001
 (2005,10A9)	Unknown (Correction distorsions)	K	Philips MR Imaging DD 001
 (2005,1013)	Unknown	K	Philips MR Imaging DD 001
+(2005,1357)	Spectro spectral width	K	Philips MR Imaging DD 004
+(2005,140F)	Private tag data	K	GEMS_IMAG_01
 (0040,0561)	Original Attributes Sequence	X	
-(7fe1,1010)	[CSA Data]	K	
+(7fe1,1010)	[CSA Data]	K	SIEMENS CSA NON-IMAGE

--- a/deidentification/config/profiles/cati_collector.tsv
+++ b/deidentification/config/profiles/cati_collector.tsv
@@ -6,19 +6,19 @@ Tags	Name	Action	Private Creator
 (0008,103E)	Series Description	K	
 (0010,0010)	Patient's Name	K	
 (0018,1060)	Trigger Time	K	
-(0019,100C)	B Value	K	
-(0019,100A)	Number of slices	K	
-(0019,101E)	Display field of view	K	
+(0019,100C)	B Value	K	SIEMENS MR HEADER
+(0019,100A)	Number of slices	K	SIEMENS MR HEADER
+(0019,101E)	Display field of view	K	GEMS_ACQU_01
 (0019,1028)	Bandwidth per pixel phase encode	K	
-(0019,105A)	Acquisition duration	K	
-(0019,107E)	Number of echoes	K	
-(0019,109F)	Transmitting Coil Type	K	
-(0019,10BB)	User data 20	K	
-(0019,10BC)	User data 21	K	
-(0019,10BD)	User data 22	K	
+(0019,105A)	Acquisition duration	K	GEMS_ACQU_01
+(0019,107E)	Number of echoes	K	GEMS_ACQU_01
+(0019,109F)	Transmitting Coil Type	K	GEMS_ACQU_01
+(0019,10BB)	User data 20	K	GEMS_ACQU_01
+(0019,10BC)	User data 21	K	GEMS_ACQU_01
+(0019,10BD)	User data 22	K	GEMS_ACQU_01
 (0021,1009)	Parallel acquisition	K	
-(0021,105A)	Diffusion direction	K	
-(0021,105E)	RTIA timer	K	
+(0021,105A)	Diffusion direction	K	GEMS_RELA_01
+(0021,105E)	RTIA timer	K	GEMS_RELA_01
 (0021,114f)	Coil information	K	
 (0021,1156)	Parallel acquisition	K	
 (0021,1175)	Acquisition type	K	
@@ -26,34 +26,34 @@ Tags	Name	Action	Private Creator
 (0021,1177)	Sequence information	K	
 (0021,1178)	Distorsion correction	K	
 (0021,1179)	Distorsion correction	K	
-(0025,1007)	Images in Series (Number of slices)	K	
-(0025,101B)	Protocol Data Block (compressed)	K	
-(0027,1060)	Image dimension - X (Reconstruction matrix)	K	
-(0043,102A)	User defined data	K	
-(0043,102C)	Effective echo spacing	K	
-(0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	
-(0043,1039)	B value	K	
-(0051,100A)	Acquistion duration	K	
-(0051,100B)	Reconstruction matrix	K	
-(0051,100C)	Field of view	K	
-(0051,100E)	Acquisition orientation	K	
-(0051,100F)	Coil	K	
-(0051,1011)	Parallel acquisition	K	
-(0051,1016)	Misc p2 M/NORM/DIS3D	K	
-(2001,1003)	Diffusion B-Factor	K	
-(2001,100B)	Slice orientation (Acquisition orientation)	K	
-(2001,1013)	EPI Factor	K	
-(2001,1014)	Number of echoes	K	
-(2001,1018)	Number of slices MR	K	
+(0025,1007)	Images in Series (Number of slices)	K	GEMS_SERS_01
+(0025,101B)	Protocol Data Block (compressed)	K	GEMS_SERS_01
+(0027,1060)	Image dimension - X	K	GEMS_IMAG_01
+(0043,102A)	User defined data	K	GEMS_PARM_01
+(0043,102C)	Effective echo spacing	K	GEMS_PARM_01
+(0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	GEMS_PARM_01
+(0043,1039)	B value	K	GEMS_PARM_01
+(0051,100A)	Acquistion duration	K	SIEMENS MR HEADER
+(0051,100B)	Reconstruction matrix	K	SIEMENS MR HEADER
+(0051,100C)	Field of view	K	SIEMENS MR HEADER
+(0051,100E)	Acquisition orientation	K	SIEMENS MR HEADER
+(0051,100F)	Coil	K	SIEMENS MR HEADER
+(0051,1011)	Parallel acquisition	K	SIEMENS MR HEADER
+(0051,1016)	Misc p2 M/NORM/DIS3D	K	SIEMENS MR HEADER
+(2001,1003)	Diffusion B-Factor	K	Philips Imaging DD 001
+(2001,100B)	Slice orientation (Acquisition orientation)	K	Philips Imaging DD 001
+(2001,1013)	EPI Factor	K	Philips Imaging DD 001
+(2001,1014)	Number of echoes	K	Philips Imaging DD 001
+(2001,1018)	Number of slices MR	K	Philips Imaging DD 001
 (2001,1020)	Scanning Technique Description MR	K	
-(2001,101B)	Prepulse Delay	K	
-(2001,1081)	Number of dynamic scans (Time points)	K	
-(2005,101D)	Unknown (Reconstruction matrix)	K	
-(2005,1074)	Unknown	K	
-(2005,1075)	Unknown	K	
-(2005,1076)	Unknown	K	
-(2005,10A1)	Syncra Scan type (correction B1)	K	
-(2005,10A9)	Unknown (Correction distorsions)	K	
-(2005,1013)	Unknown	K	
+(2001,101B)	Prepulse Delay	K	Philips Imaging DD 001
+(2001,1081)	Number of dynamic scans (Time points)	K	Philips Imaging DD 001
+(2005,101D)	Unknown (Reconstruction matrix)	K	Philips MR Imaging DD 001
+(2005,1074)	Unknown	K	Philips MR Imaging DD 001
+(2005,1075)	Unknown	K	Philips MR Imaging DD 001
+(2005,1076)	Unknown	K	Philips MR Imaging DD 001
+(2005,10A1)	Syncra Scan type (correction B1)	K	Philips MR Imaging DD 001
+(2005,10A9)	Unknown (Correction distorsions)	K	Philips MR Imaging DD 001
+(2005,1013)	Unknown	K	Philips MR Imaging DD 001
 (0040,0561)	Original Attributes Sequence	X	
 (7fe1,1010)	[CSA Data]	K	

--- a/deidentification/config/profiles/cati_collector.tsv
+++ b/deidentification/config/profiles/cati_collector.tsv
@@ -1,59 +1,59 @@
-Tags	Name	Action
-(0008,0020)	Study Date	
-(0008,0031)	Series Time	
-(0008,0032)	Acquisition Time	
-(0008,0033)	Content Time	
-(0008,103E)	Series Description	
-(0010,0010)	Patient's Name	
-(0018,1060)	Trigger Time	
-(0019,100C)	B Value	
-(0019,100A)	Number of slices	
-(0019,101E)	Display field of view	
-(0019,1028)	Bandwidth per pixel phase encode	
-(0019,105A)	Acquisition duration	
-(0019,107E)	Number of echoes	
-(0019,109F)	Transmitting Coil Type	
-(0019,10BB)	User data 20	
-(0019,10BC)	User data 21	
-(0019,10BD)	User data 22	
-(0021,1009)	Parallel acquisition	
-(0021,105A)	Diffusion direction	
-(0021,105E)	RTIA timer	
-(0021,114f)	Coil information	
-(0021,1156)	Parallel acquisition	
-(0021,1175)	Acquisition type	
-(0021,1176)	Correction information	
-(0021,1177)	Sequence information	
-(0021,1178)	Distorsion correction	
-(0021,1179)	Distorsion correction	
-(0025,1007)	Images in Series (Number of slices)	
-(0025,101B)	Protocol Data Block (compressed)	
-(0027,1060)	Image dimension - X (Reconstruction matrix)	
-(0043,102A)	User defined data	
-(0043,102C)	Effective echo spacing	
-(0043,102F)	Image Type (real,imaginary,phase,magnitude)	
-(0043,1039)	B value	
-(0051,100A)	Acquistion duration	
-(0051,100B)	Reconstruction matrix	
-(0051,100C)	Field of view	
-(0051,100E)	Acquisition orientation	
-(0051,100F)	Coil	
-(0051,1011)	Parallel acquisition	
-(0051,1016)	Misc p2 M/NORM/DIS3D	
-(2001,1003)	Diffusion B-Factor	
-(2001,100B)	Slice orientation (Acquisition orientation)	
-(2001,1013)	EPI Factor	
-(2001,1014)	Number of echoes	
-(2001,1018)	Number of slices MR	
-(2001,1020)	Scanning Technique Description MR	
-(2001,101B)	Prepulse Delay	
-(2001,1081)	Number of dynamic scans (Time points)	
-(2005,101D)	Unknown (Reconstruction matrix)	
-(2005,1074)	Unknown	
-(2005,1075)	Unknown	
-(2005,1076)	Unknown	
-(2005,10A1)	Syncra Scan type (correction B1)	
-(2005,10A9)	Unknown (Correction distorsions)	
-(2005,1013)	Unknown	
-(0040,0561)	Original Attributes Sequence	X
-(7fe1,1010)	[CSA Data]	
+Tags	Name	Action	Private Creator
+(0008,0020)	Study Date	K	
+(0008,0031)	Series Time	K	
+(0008,0032)	Acquisition Time	K	
+(0008,0033)	Content Time	K	
+(0008,103E)	Series Description	K	
+(0010,0010)	Patient's Name	K	
+(0018,1060)	Trigger Time	K	
+(0019,100C)	B Value	K	
+(0019,100A)	Number of slices	K	
+(0019,101E)	Display field of view	K	
+(0019,1028)	Bandwidth per pixel phase encode	K	
+(0019,105A)	Acquisition duration	K	
+(0019,107E)	Number of echoes	K	
+(0019,109F)	Transmitting Coil Type	K	
+(0019,10BB)	User data 20	K	
+(0019,10BC)	User data 21	K	
+(0019,10BD)	User data 22	K	
+(0021,1009)	Parallel acquisition	K	
+(0021,105A)	Diffusion direction	K	
+(0021,105E)	RTIA timer	K	
+(0021,114f)	Coil information	K	
+(0021,1156)	Parallel acquisition	K	
+(0021,1175)	Acquisition type	K	
+(0021,1176)	Correction information	K	
+(0021,1177)	Sequence information	K	
+(0021,1178)	Distorsion correction	K	
+(0021,1179)	Distorsion correction	K	
+(0025,1007)	Images in Series (Number of slices)	K	
+(0025,101B)	Protocol Data Block (compressed)	K	
+(0027,1060)	Image dimension - X (Reconstruction matrix)	K	
+(0043,102A)	User defined data	K	
+(0043,102C)	Effective echo spacing	K	
+(0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	
+(0043,1039)	B value	K	
+(0051,100A)	Acquistion duration	K	
+(0051,100B)	Reconstruction matrix	K	
+(0051,100C)	Field of view	K	
+(0051,100E)	Acquisition orientation	K	
+(0051,100F)	Coil	K	
+(0051,1011)	Parallel acquisition	K	
+(0051,1016)	Misc p2 M/NORM/DIS3D	K	
+(2001,1003)	Diffusion B-Factor	K	
+(2001,100B)	Slice orientation (Acquisition orientation)	K	
+(2001,1013)	EPI Factor	K	
+(2001,1014)	Number of echoes	K	
+(2001,1018)	Number of slices MR	K	
+(2001,1020)	Scanning Technique Description MR	K	
+(2001,101B)	Prepulse Delay	K	
+(2001,1081)	Number of dynamic scans (Time points)	K	
+(2005,101D)	Unknown (Reconstruction matrix)	K	
+(2005,1074)	Unknown	K	
+(2005,1075)	Unknown	K	
+(2005,1076)	Unknown	K	
+(2005,10A1)	Syncra Scan type (correction B1)	K	
+(2005,10A9)	Unknown (Correction distorsions)	K	
+(2005,1013)	Unknown	K	
+(0040,0561)	Original Attributes Sequence	X	
+(7fe1,1010)	[CSA Data]	K	

--- a/deidentification/config/profiles/data_sharing.tsv
+++ b/deidentification/config/profiles/data_sharing.tsv
@@ -1,53 +1,53 @@
-Tags	Name	Action
-(0018,1060)	Trigger Time	
-(0019,100C)	B Value	
-(0019,100A)	Number of slices	
-(0019,101E)	Display field of view	
-(0019,1028)	Bandwidth per pixel phase encode	
-(0019,105A)	Acquisition duration	
-(0019,107E)	Number of echoes	
-(0019,109F)	Transmitting Coil Type	
-(0019,10BB)	User data 20	
-(0019,10BC)	User data 21	
-(0019,10BD)	User data 22	
-(0021,1009)	Parallel acquisition	
-(0021,105A)	Diffusion direction	
-(0021,105E)	RTIA timer	
-(0021,114f)	Coil information	
-(0021,1156)	Parallel acquisition	
-(0021,1175)	Acquisition type	
-(0021,1176)	Correction information	
-(0021,1177)	Sequence information	
-(0021,1178)	Distorsion correction	
-(0021,1179)	Distorsion correction	
-(0025,1007)	Images in Series (Number of slices)	
-(0025,101B)	Protocol Data Block (compressed)	
-(0027,1060)	Image dimension - X (Reconstruction matrix)	
-(0043,102A)	User defined data	
-(0043,102C)	Effective echo spacing	
-(0043,102F)	Image Type (real,imaginary,phase,magnitude)	
-(0043,1039)	B value	
-(0051,100A)	Acquistion duration	
-(0051,100B)	Reconstruction matrix	
-(0051,100C)	Field of view	
-(0051,100E)	Acquisition orientation	
-(0051,100F)	Coil	
-(0051,1011)	Parallel acquisition	
-(0051,1016)	Misc p2 M/NORM/DIS3D	
-(2001,1003)	Diffusion B-Factor	
-(2001,100B)	Slice orientation (Acquisition orientation)	
-(2001,1013)	EPI Factor	
-(2001,1014)	Number of echoes	
-(2001,1018)	Number of slices MR	
-(2001,1020)	Scanning Technique Description MR	
-(2001,101B)	Prepulse Delay	
-(2001,1081)	Number of dynamic scans (Time points)	
-(2005,101D)	Unknown (Reconstruction matrix)	
-(2005,1074)	Unknown	
-(2005,1075)	Unknown	
-(2005,1076)	Unknown	
-(2005,10A1)	Syncra Scan type (correction B1)	
-(2005,10A9)	Unknown (Correction distorsions)	
-(2005,1013)	Unknown	
-(0040,0561)	Original Attributes Sequence	X
-(7fe1,1010)	[CSA Data]	
+Tags	Name	Action	Private Creator
+(0018,1060)	Trigger Time	K	
+(0019,100C)	B Value	K	SIEMENS MR HEADER
+(0019,100A)	Number of slices	K	SIEMENS MR HEADER
+(0019,101E)	Display field of view	K	GEMS_ACQU_01
+(0019,1028)	Bandwidth per pixel phase encode	K	
+(0019,105A)	Acquisition duration	K	GEMS_ACQU_01
+(0019,107E)	Number of echoes	K	GEMS_ACQU_01
+(0019,109F)	Transmitting Coil Type	K	GEMS_ACQU_01
+(0019,10BB)	User data 20	K	GEMS_ACQU_01
+(0019,10BC)	User data 21	K	GEMS_ACQU_01
+(0019,10BD)	User data 22	K	GEMS_ACQU_01
+(0021,1009)	Parallel acquisition	K	
+(0021,105A)	Diffusion direction	K	GEMS_RELA_01
+(0021,105E)	RTIA timer	K	GEMS_RELA_01
+(0021,114f)	Coil information	K	
+(0021,1156)	Parallel acquisition	K	
+(0021,1175)	Acquisition type	K	
+(0021,1176)	Correction information	K	
+(0021,1177)	Sequence information	K	
+(0021,1178)	Distorsion correction	K	
+(0021,1179)	Distorsion correction	K	
+(0025,1007)	Images in Series (Number of slices)	K	GEMS_SERS_01
+(0025,101B)	Protocol Data Block (compressed)	K	GEMS_SERS_01
+(0027,1060)	Image dimension - X (Reconstruction matrix)	K	GEMS_PARM_01
+(0043,102A)	User defined data	K	GEMS_PARM_01
+(0043,102C)	Effective echo spacing	K	GEMS_PARM_01
+(0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	GEMS_PARM_01
+(0043,1039)	B value	K	GEMS_PARM_01
+(0051,100A)	Acquistion duration	K	SIEMENS MR HEADER
+(0051,100B)	Reconstruction matrix	K	SIEMENS MR HEADER
+(0051,100C)	Field of view	K	SIEMENS MR HEADER
+(0051,100E)	Acquisition orientation	K	SIEMENS MR HEADER
+(0051,100F)	Coil	K	SIEMENS MR HEADER
+(0051,1011)	Parallel acquisition	K	SIEMENS MR HEADER
+(0051,1016)	Misc p2 M/NORM/DIS3D	K	SIEMENS MR HEADER
+(2001,1003)	Diffusion B-Factor	K	Philips Imaging DD 001
+(2001,100B)	Slice orientation (Acquisition orientation)	K	Philips Imaging DD 001
+(2001,1013)	EPI Factor	K	Philips Imaging DD 001
+(2001,1014)	Number of echoes	K	Philips Imaging DD 001
+(2001,1018)	Number of slices MR	K	Philips Imaging DD 001
+(2001,1020)	Scanning Technique Description MR	K	
+(2001,101B)	Prepulse Delay	K	Philips Imaging DD 001
+(2001,1081)	Number of dynamic scans (Time points)	K	Philips Imaging DD 001
+(2005,101D)	Unknown (Reconstruction matrix)	K	Philips MR Imaging DD 001
+(2005,1074)	Unknown	K	Philips MR Imaging DD 001
+(2005,1075)	Unknown	K	Philips MR Imaging DD 001
+(2005,1076)	Unknown	K	Philips MR Imaging DD 001
+(2005,10A1)	Syncra Scan type (correction B1)	K	Philips MR Imaging DD 001
+(2005,10A9)	Unknown (Correction distorsions)	K	Philips MR Imaging DD 001
+(2005,1013)	Unknown	K	Philips MR Imaging DD 001
+(0040,0561)	Original Attributes Sequence	X	
+(7fe1,1010)	[CSA Data]	K	

--- a/deidentification/config/profiles/data_sharing.tsv
+++ b/deidentification/config/profiles/data_sharing.tsv
@@ -1,5 +1,6 @@
 Tags	Name	Action	Private Creator
 (0018,1060)	Trigger Time	K	
+(0019,0010)	Private Creator	K	GEMS_ACQU_01
 (0019,100C)	B Value	K	SIEMENS MR HEADER
 (0019,100A)	Number of slices	K	SIEMENS MR HEADER
 (0019,101E)	Display field of view	K	GEMS_ACQU_01
@@ -10,19 +11,22 @@ Tags	Name	Action	Private Creator
 (0019,10BB)	User data 20	K	GEMS_ACQU_01
 (0019,10BC)	User data 21	K	GEMS_ACQU_01
 (0019,10BD)	User data 22	K	GEMS_ACQU_01
-(0021,1009)	Parallel acquisition	K	
+(0021,0010)	Private Creator	K	SIEMENS MR SDS 01
+(0021,0011)	Private Creator	K	SIEMENS MR SDS 01
+(0021,1009)	Parallel acquisition	K	SIEMENS MR SDS 01
 (0021,105A)	Diffusion direction	K	GEMS_RELA_01
 (0021,105E)	RTIA timer	K	GEMS_RELA_01
-(0021,114f)	Coil information	K	
-(0021,1156)	Parallel acquisition	K	
-(0021,1175)	Acquisition type	K	
-(0021,1176)	Correction information	K	
-(0021,1177)	Sequence information	K	
-(0021,1178)	Distorsion correction	K	
-(0021,1179)	Distorsion correction	K	
+(0021,114f)	Coil information	K	SIEMENS MR SDI 02
+(0021,1156)	Parallel acquisition	K	SIEMENS MR SDI 02
+(0021,1175)	Acquisition type	K	SIEMENS MR SDI 02
+(0021,1176)	Correction information	K	SIEMENS MR SDI 02
+(0021,1177)	Sequence information	K	SIEMENS MR SDI 02
+(0021,1178)	Distorsion correction	K	SIEMENS MR SDI 02
+(0021,1179)	Distorsion correction	K	SIEMENS MR SDI 02
 (0025,1007)	Images in Series (Number of slices)	K	GEMS_SERS_01
 (0025,101B)	Protocol Data Block (compressed)	K	GEMS_SERS_01
 (0027,1060)	Image dimension - X (Reconstruction matrix)	K	GEMS_PARM_01
+(0027,1062)	Number of Excitations		GEMS_IMAG_01
 (0043,102A)	User defined data	K	GEMS_PARM_01
 (0043,102C)	Effective echo spacing	K	GEMS_PARM_01
 (0043,102F)	Image Type (real,imaginary,phase,magnitude)	K	GEMS_PARM_01
@@ -39,15 +43,25 @@ Tags	Name	Action	Private Creator
 (2001,1013)	EPI Factor	K	Philips Imaging DD 001
 (2001,1014)	Number of echoes	K	Philips Imaging DD 001
 (2001,1018)	Number of slices MR	K	Philips Imaging DD 001
-(2001,1020)	Scanning Technique Description MR	K	
+(2001,1020)	Scanning Technique Description MR	K	Philips Imaging DD 001
 (2001,101B)	Prepulse Delay	K	Philips Imaging DD 001
 (2001,1081)	Number of dynamic scans (Time points)	K	Philips Imaging DD 001
+(2005,0010)	Private Creator	K	Philips MR Imaging DD 001
 (2005,101D)	Unknown (Reconstruction matrix)	K	Philips MR Imaging DD 001
+(2005,1030)	Spectro Repetition Time	K	Philips MR Imaging DD 001
+(2005,1057)	Spectro voxel dim 1	K	Philips MR Imaging DD 001
+(2005,1058)	Spectro voxel dim 2	K	Philips MR Imaging DD 001
+(2005,1059)	Spectro voxel dim 3	K	Philips MR Imaging DD 001
+(2005,105a)	Spectro voxel coordinate 1	K	Philips MR Imaging DD 001
+(2005,105b)	Spectro voxel coordinate 2	K	Philips MR Imaging DD 001
+(2005,105c)	Spectro voxel coordinate 3	K	Philips MR Imaging DD 001
 (2005,1074)	Unknown	K	Philips MR Imaging DD 001
 (2005,1075)	Unknown	K	Philips MR Imaging DD 001
 (2005,1076)	Unknown	K	Philips MR Imaging DD 001
 (2005,10A1)	Syncra Scan type (correction B1)	K	Philips MR Imaging DD 001
 (2005,10A9)	Unknown (Correction distorsions)	K	Philips MR Imaging DD 001
 (2005,1013)	Unknown	K	Philips MR Imaging DD 001
+(2005,1357)	Spectro spectral width	K	Philips MR Imaging DD 004
+(2005,140F)	Private tag data	K	GEMS_IMAG_01
 (0040,0561)	Original Attributes Sequence	X	
-(7fe1,1010)	[CSA Data]	K	
+(7fe1,1010)	[CSA Data]	K	SIEMENS CSA NON-IMAGE

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -194,12 +194,12 @@ def test_anonymize_config_safe_private(dicom_path):
     tags_config = {
         # Private Creator tag to be kept
         (0x2005, 0x0011): {
-            'name': ds.get((0x2005, 0x0011)).value,
+            'private_creator': ds.get((0x2005, 0x0011)).value,
             'action': 'K'
         },
         # Private Creator tag with wrong name
         (0x2005, 0x0012): {
-            'name': 'XX',
+            'private_creator': 'XX',
             'action': 'K'
         }
     }

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -107,15 +107,15 @@ def test_anonymizer_private_tags(dicom_path):
 def test_anonymizer_private_creator(dicom_path):
     from deidentification import anonymizer
     tags_config = {
-        (0x2005, 0x100d): {'action': 'K', 'private_creator': 'Philips MR Imaging DD 001'},
-        (0x2005, 0x100e): {'action': 'K', 'private_creator': 'TOTO'},
+        (0x2005, 0x101d): {'action': 'K', 'private_creator': 'Philips MR Imaging DD 001'},
+        (0x2005, 0x1013): {'action': 'K', 'private_creator': 'TOTO'},
     }
     a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
                               tags_config=tags_config)
     a.run_ano()
     ds = pydicom.read_file(path_ano(dicom_path))
-    assert ds.get((0x2005, 0x100d), None)
-    assert not ds.get((0x2005, 0x100e), None)
+    assert ds.get((0x2005, 0x101d), None)
+    assert not ds.get((0x2005, 0x1013), None)
 
 
 def test_anonymizer_data_sharing_profile(dicom_path):

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -104,6 +104,20 @@ def test_anonymizer_private_tags(dicom_path):
     assert ds.get((0x2001, 0x1003), None)
 
 
+def test_anonymizer_private_creator(dicom_path):
+    from deidentification import anonymizer
+    tags_config = {
+        (0x2005, 0x100d): {'action': 'K', 'private_creator': 'Philips MR Imaging DD 001'},
+        (0x2005, 0x100e): {'action': 'K', 'private_creator': 'TOTO'},
+    }
+    a = anonymizer.Anonymizer(dicom_path, path_ano(dicom_path),
+                              tags_config=tags_config)
+    a.run_ano()
+    ds = pydicom.read_file(path_ano(dicom_path))
+    assert ds.get((0x2005, 0x100d), None)
+    assert not ds.get((0x2005, 0x100e), None)
+
+
 def test_anonymizer_data_sharing_profile(dicom_path):
     from deidentification import anonymizer
     from deidentification.config import load_config_profile


### PR DESCRIPTION
This branch adds a new column to config profiles that contain Private Creator value to be checked for private tags. It is also possible to add Private Creator tags them selfs to the config profile to apply action on all depending tags.
For now, the use of Private Creator is not mandatory in config profiles.