### PR TITLE
Multiple private creator

### DIFF
--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -421,7 +421,7 @@ class Anonymizer():
                     and self._tags_config[tag].get('private_creator')
                     and not self._is_private_creator(data_element.tag.group, data_element.tag.element)):
                 private_creator = ds.get(self._get_private_creator_tag(data_element), None)
-                if not private_creator or private_creator.value != self._tags_config[tag].get('private_creator'):
+                if not private_creator or private_creator.value not in self._tags_config[tag].get('private_creator'):
                     do_apply_action = False
             if do_apply_action:
                 action = self._tags_config[tag]['action']
@@ -448,7 +448,7 @@ class Anonymizer():
             # Check if private creator in tag_config
             if (self._tags_config is not None
                     and private_creator_tag in self._tags_config
-                    and private_creator.value == self._tags_config[private_creator_tag]['private_creator']):
+                    and private_creator.value in self._tags_config[private_creator_tag]['private_creator']):
                 self._apply_action(ds, data_element, self._tags_config[private_creator_tag]['action'])
                 return
             # Check if the private creator is in the safe private attribute keys

--- a/deidentification/config.py
+++ b/deidentification/config.py
@@ -42,9 +42,9 @@ def load_config_profile(profile: str, anonymous: bool = False):
                     action = 'K'
                 else:
                     action = d[2]
-                tags_profile[tag_to_tuple(d[0])] = {'name': d[1], 'action': action}
+                tags_profile.setdefault(tag_to_tuple(d[0]), {}).update({'name': d[1], 'action': action})
                 if len(d) > 3:
-                    tags_profile[tag_to_tuple(d[0])].update({'private_creator': d[3]})
+                    tags_profile[tag_to_tuple(d[0])].setdefault('private_creator', []).append(d[3])
     except ValueError as e:
         if anonymous:
             tag_load_error = 'Error occurs during config profile load.'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+import csv
+import tempfile
+
+
+def create_fake_config(config: list) -> str:
+    tmp_config = tempfile.NamedTemporaryFile(delete=False)
+    with open(tmp_config.name, 'w') as conf:
+        conf_writer = csv.writer(conf, delimiter='\t')
+        conf_writer.writerow(['Tag', 'Name', 'Action', 'Private Creator'])
+        if isinstance(config[0], list):
+            conf_writer.writerows(config)
+        else:
+            conf_writer.writerow(config)
+    return tmp_config.name

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 import pytest
 
+from . import create_fake_config
+
 
 def test_tag_lists():
     from deidentification.tag_lists import conf_profile, conf_profile_range
@@ -41,3 +43,14 @@ def test_tag_to_tuple():
     for wrong_tag in wrong_tags:
         with pytest.raises(ValueError, match=r"Input tag .* must contains .*"):
             tag_to_tuple(wrong_tag)
+
+
+def test_multiple_private_creator_name():
+    from deidentification.config import load_config_profile
+    tmp_config = create_fake_config([
+        ['(2005,0010)', 'Private Creator', 'K', 'Name1'],
+        ['(2005,0010)', 'Private Creator', 'K', 'Name2']
+    ])
+    
+    config = load_config_profile(tmp_config)
+    assert len(config[(0x2005, 0x0010)]['private_creator']) == 2


### PR DESCRIPTION
Add the possibility to use several Private Creator values for the same private tag.
It allows config : 

| Tag | Name| Action | Private Creator |
| --- | --- | --- | --- |
| (2005, 0010) | Private Creator Tag | K | SIEMENS MR SDS 01 |
| (2005, 0010) | Private Creator Tag | K | SIEMENS MR SDI 02 |