### PR TITLE
Use UNIX Epoch to de-identify dates

### DIFF
--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -525,10 +525,12 @@ class Anonymizer():
         """
         if data_element.VR == 'UI':
             return self._generate_uuid(data_element.value)
-        if data_element.VR in ('DT', 'TM'):
+        if data_element.VR == 'DA':
+            return "19700101"
+        if data_element.VR == 'TM':
             return "000000.00"
-        elif data_element.VR == 'DA':
-            return "20000101"
+        if data_element.VR == 'DT':
+            return "19700101000000.00"
         return "no value"
 
     def _is_private_creator(self, group, element):


### PR DESCRIPTION
UNIX Epoch conveys much better the message that the date is not to be taken into account - DICOM and MRI did exist in 2000 but not in 1970.