### PR TITLE
Relax pydicom version requirement

### DIFF
--- a/deidentification/info.py
+++ b/deidentification/info.py
@@ -17,6 +17,6 @@ AUTHOR = 'CATI'
 LICENSE = 'MIT License'
 AUTHOR_EMAIL = 'support@cati-neuroimaging.com'
 VERSION = __version__
-REQUIRES = ['pydicom<2.3,>=1.4.2']
+REQUIRES = ['pydicom<3,>=1.4.2']
 
 brainvisa_build_model = 'pure_python'


### PR DESCRIPTION
With the constraint pydicom<2.3, installing deidentification with pixi also install pydicom 2.2. But this version has a bug that makes QualiCATI fail during module loading. With this PR (setting pydicom<3), pydicom 2.4.4 is installed and the import does not fail.