### PR TITLE
Remove folder hierarchy in output & handle .zip in folder to ano

### DIFF
--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -109,24 +109,22 @@ def anonymize_file(dicom_file_in, dicom_folder_out,
         profile_name = config_profile
     
     # Check for screen capture files
-    if capture_type := is_capture(dicom_file_in):
-        if capture_folder:
-            os.makedirs(capture_folder, exist_ok=True)
-            if capture_type == "image":
-                # move file to a "captures" folder
-                capture_file_out = _get_unique_output_path(dicom_file_in, capture_folder)
-                shutil.copy2(dicom_file_in, capture_file_out)
-                return
-            elif capture_type == "dicom":
-                file_out = _get_unique_output_path(dicom_file_in, capture_folder)
-                anon = Anonymizer(dicom_file_in, file_out,
-                                tags_config, forced_values,
-                                anonymous=anonymous,
-                                config_profile=profile_name,
-                                report_path=report_path,
-                                keep_capture=True)
-                anon.run_ano()
-                return
+    if (capture_type := is_capture(dicom_file_in)) and capture_folder:
+        os.makedirs(capture_folder, exist_ok=True)
+        file_out = _get_unique_output_path(dicom_file_in, capture_folder)
+        if capture_type == "image":
+            # move file to a "captures" folder
+            shutil.copy2(dicom_file_in, file_out)
+            return
+        elif capture_type == "dicom":
+            anon = Anonymizer(dicom_file_in, file_out,
+                            tags_config, forced_values,
+                            anonymous=anonymous,
+                            config_profile=profile_name,
+                            report_path=report_path,
+                            keep_capture=True)
+            anon.run_ano()
+            return
 
     os.makedirs(dicom_folder_out, exist_ok=True)
     dicom_file_out = _get_unique_output_path(dicom_file_in, dicom_folder_out)
@@ -524,7 +522,7 @@ def _get_private_creator_tag(data_element):
     return pydicom.tag.Tag(group, element)
 
 
-class Anonymizer():
+class Anonymizer:
 
     """
     Anonymizes a DICOM file according to DICOM standard.
@@ -560,10 +558,9 @@ class Anonymizer():
         """
         Reads the DICOM file, anonymizes it and write the result.
         """
-        if not is_imaging_modality(self._dataset):
-            if not self.keep_capture or not is_capture_dicom(self._dataset):
-                self.fill_report('removed')
-                return 0
+        if not is_imaging_modality(self._dataset) and (not self.keep_capture or not is_capture_dicom(self._dataset)):
+            self.fill_report("removed")
+            return 0
         if not self.ano_run:
             self._dataset.walk(self._anonymize_check)
 

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -194,27 +194,52 @@ def anonymize(dicom_in, dicom_out,
     # Launch deidentification
     try:
         if os.path.isfile(wip_dicom_in):
-            anonymize_file(wip_dicom_in, wip_dicom_out,
-                           tags_to_keep, tags_to_delete,
-                           forced_values=forced_values,
-                           anonymous=anonymous,
-                           config_profile=config_profile,
-                           report_path=deidentification_report,
-                           capture_folder=capture_folder)
+            if is_archive_file(wip_dicom_in):
+                anonymize(
+                    wip_dicom_in,
+                    wip_dicom_out,
+                    tags_to_keep=tags_to_keep,
+                    tags_to_delete=tags_to_delete,
+                    forced_values=forced_values,
+                    config_profile=config_profile,
+                    anonymous=anonymous,
+                    tempdir_prefix=tempdir_prefix,
+                    error_no_dicom=error_no_dicom,
+                    keep_capture=keep_capture
+                )
+            else:
+                anonymize_file(wip_dicom_in, wip_dicom_out,
+                            tags_to_keep, tags_to_delete,
+                            forced_values=forced_values,
+                            anonymous=anonymous,
+                            config_profile=config_profile,
+                            report_path=deidentification_report,
+                            capture_folder=capture_folder)
 
         elif os.path.isdir(wip_dicom_in):
             for root, dirs, files in os.walk(wip_dicom_in):
-                folder_out = root.replace(wip_dicom_in, wip_dicom_out)
                 for name in files:
                     current_file = os.path.join(root, name)
                     try:
-                        anonymize_file(current_file, folder_out,
-                                       tags_to_keep, tags_to_delete,
-                                       forced_values=forced_values,
-                                       anonymous=anonymous,
-                                       config_profile=config_profile,
-                                       report_path=deidentification_report,
-                                       capture_folder=capture_folder)
+                        if is_archive_file(current_file):
+                            anonymize(
+                                current_file, wip_dicom_out,
+                                tags_to_keep, tags_to_delete,
+                                forced_values=forced_values,
+                                config_profile=config_profile,
+                                anonymous=anonymous,
+                                tempdir_prefix=tempdir_prefix,
+                                error_no_dicom=error_no_dicom,
+                                keep_capture=keep_capture
+                            )
+                        else:
+                            anonymize_file(current_file, wip_dicom_out,
+                                        tags_to_keep, tags_to_delete,
+                                        forced_values=forced_values,
+                                        anonymous=anonymous,
+                                        config_profile=config_profile,
+                                        report_path=deidentification_report,
+                                        capture_folder=capture_folder)
                     except AnonymizerError as e:
                         # Raise an error only if no DICOM file
                         if error_no_dicom:

--- a/deidentification/anonymizer.py
+++ b/deidentification/anonymizer.py
@@ -57,6 +57,23 @@ def _load_config(config_profile, tags_to_keep, tags_to_delete, anonymous):
     return tags_config
 
 
+def _get_unique_output_path(dicom_file_in, output_folder):
+    input_name = os.path.basename(dicom_file_in)
+    output_path = os.path.join(output_folder, input_name)
+    stem, ext = os.path.splitext(input_name)
+    counter = 1
+
+    while os.path.exists(output_path):
+        if ext:
+            candidate_name = f'{stem}_{counter}{ext}'
+        else:
+            candidate_name = f'{input_name}_{counter}'
+        output_path = os.path.join(output_folder, candidate_name)
+        counter += 1
+
+    return output_path
+
+
 def anonymize_file(dicom_file_in, dicom_folder_out,
                    tags_to_keep=None,
                    tags_to_delete=None,
@@ -97,10 +114,11 @@ def anonymize_file(dicom_file_in, dicom_folder_out,
             os.makedirs(capture_folder, exist_ok=True)
             if capture_type == "image":
                 # move file to a "captures" folder
-                shutil.copy2(dicom_file_in, os.path.join(capture_folder, os.path.basename(dicom_file_in)))
+                capture_file_out = _get_unique_output_path(dicom_file_in, capture_folder)
+                shutil.copy2(dicom_file_in, capture_file_out)
                 return
             elif capture_type == "dicom":
-                file_out = os.path.join(capture_folder, os.path.basename(dicom_file_in))
+                file_out = _get_unique_output_path(dicom_file_in, capture_folder)
                 anon = Anonymizer(dicom_file_in, file_out,
                                 tags_config, forced_values,
                                 anonymous=anonymous,
@@ -111,8 +129,7 @@ def anonymize_file(dicom_file_in, dicom_folder_out,
                 return
 
     os.makedirs(dicom_folder_out, exist_ok=True)
-    dicom_file_out = os.path.join(dicom_folder_out,
-                                  os.path.basename(dicom_file_in))
+    dicom_file_out = _get_unique_output_path(dicom_file_in, dicom_folder_out)
 
     # Keep spectro non DICOM data
     if not is_dicom(dicom_file_in) and is_spectro(dicom_file_in):

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -278,26 +278,26 @@ def test_anonymize_private_creator_tree(dicom_path):
     ds.add_new((0x3030, 0x1001), 'SQ', [sequence_block])
     ds.add_new((0x3035, 0x0010), 'SH', 'Test deid2')
 
-    tmp_file = tempfile.NamedTemporaryFile()
-    tmp_file_path = tmp_file.name
-    ds.save_as(tmp_file_path)
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file_path = tmp_file.name
+        ds.save_as(tmp_file_path)
 
-    tags_config = {
-        (0x3033, 0x1011): {
-            'private_creator': 'Test deidentification',
-            'action': 'K'
-        },
-        (0x3035, 0x1011): {
-            'private_creator': 'Test deidentification2',
-            'action': 'K'
+        tags_config = {
+            (0x3033, 0x1011): {
+                'private_creator': 'Test deidentification',
+                'action': 'K'
+            },
+            (0x3035, 0x1011): {
+                'private_creator': 'Test deidentification2',
+                'action': 'K'
+            }
         }
-    }
 
-    output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
-    anon = Anonymizer(tmp_file_path,
-                      osp.abspath(output_dicom_path),
-                      tags_config)
-    anon.run_ano()
+        output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
+        anon = Anonymizer(tmp_file_path,
+                        osp.abspath(output_dicom_path),
+                        tags_config)
+        anon.run_ano()
 
     ds = pydicom.read_file(osp.abspath(output_dicom_path))
 
@@ -324,15 +324,15 @@ def test_ano_several_private_creator_name(dicom_path):
     ds.add_new((0x3030, 0x1001), 'SQ', [sequence_block])
     ds.add_new((0x3034, 0x1001), 'SQ', [sequence_block2])
 
-    tmp_file = tempfile.NamedTemporaryFile()
-    tmp_file_path = tmp_file.name
-    ds.save_as(tmp_file_path)
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file_path = tmp_file.name
+        ds.save_as(tmp_file_path)
 
-    output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
-    anon = Anonymizer(tmp_file_path,
-                      osp.abspath(output_dicom_path),
-                      load_config_profile(tmp_config))
-    anon.run_ano()
+        output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
+        anon = Anonymizer(tmp_file_path,
+                        osp.abspath(output_dicom_path),
+                        load_config_profile(tmp_config))
+        anon.run_ano()
 
     ds = pydicom.read_file(osp.abspath(output_dicom_path))
 
@@ -365,15 +365,16 @@ def test_anonymize_non_dicom_w_err_wo_seriesdescription(dicom_path):
     if ds.get('SeriesDescription', None) is not None:
         del ds['SeriesDescription']
     ds.Modality = "ANN"
-    tmp_file = tempfile.NamedTemporaryFile()
-    tmp_file_path = tmp_file.name
-    ds.save_as(tmp_file_path)
-    output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
-    anonymize(tmp_file_path, output_dicom_path)
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_file_path = tmp_file.name
+        ds.save_as(tmp_file_path)
+        output_dicom_path = os.path.join(OUTPUT_DIR, os.path.basename(dicom_path))
+        anonymize(tmp_file_path, output_dicom_path)
        
 
 def test_anonymize_non_dicom_wo_err(dicom_with_other):
     dicom_folder, tmp_folder = dicom_with_other
+    anonymize(dicom_folder, tmp_folder, error_no_dicom=False)
 
 
 def test_remove_folder_hierarchy(dicom_with_other):

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -100,6 +100,22 @@ def spectro_path(request):
     clean_outputs(file_path)
 
 
+@pytest.fixture()
+def dicom_duplicate_filename(dicom_path):
+    tmp_folder = tempfile.mkdtemp()
+    folder1 = osp.join(tmp_folder, "folder1")
+    folder2 = osp.join(tmp_folder, "folder2")
+    os.mkdir(folder1)
+    os.mkdir(folder2)
+    shutil.copy2(dicom_path, osp.join(folder1, osp.basename(dicom_path)))
+    shutil.copy2(dicom_path, osp.join(folder2, osp.basename(dicom_path)))
+
+    yield tmp_folder
+
+    clean_outputs(tmp_folder)
+    shutil.rmtree(tmp_folder)
+
+
 # Anonymizer class tests
 
 def test_anonymizer_basic(dicom_path):
@@ -338,7 +354,7 @@ def test_anonymize_non_imaging_dicom(dicom_non_imaging_archives_path):
 
 def test_anonymize_non_dicom_w_err(dicom_with_other):
     dicom_folder, tmp_folder = dicom_with_other
-    with pytest.raises(anonymizer.AnonymizerError, match=f".*not a DICOM file.*{dicom_folder}.*"):
+    with pytest.raises(anonymizer.AnonymizerError, match=".*not a DICOM file.*"):
         anonymize(dicom_folder, tmp_folder, error_no_dicom=True)
 
 
@@ -359,6 +375,12 @@ def test_anonymize_non_dicom_w_err_wo_seriesdescription(dicom_path):
 def test_anonymize_non_dicom_wo_err(dicom_with_other):
     dicom_folder, tmp_folder = dicom_with_other
     anonymize(DICOM_DATA_DIR, tmp_folder, error_no_dicom=False)
+
+
+def test_keep_duplicate_filename(dicom_duplicate_filename):
+    anonymize(dicom_duplicate_filename, path_ano(dicom_duplicate_filename))
+    assert osp.exists(path_ano(dicom_duplicate_filename))
+    assert len(os.listdir(path_ano(dicom_duplicate_filename))) == 2
 
 
 def test_anonymize_spectro(spectro_path):

--- a/tests/test_ano.py
+++ b/tests/test_ano.py
@@ -374,7 +374,13 @@ def test_anonymize_non_dicom_w_err_wo_seriesdescription(dicom_path):
 
 def test_anonymize_non_dicom_wo_err(dicom_with_other):
     dicom_folder, tmp_folder = dicom_with_other
-    anonymize(DICOM_DATA_DIR, tmp_folder, error_no_dicom=False)
+
+
+def test_remove_folder_hierarchy(dicom_with_other):
+    dicom_folder, tmp_folder = dicom_with_other
+    anonymize(dicom_folder, tmp_folder, error_no_dicom=False)
+    for filepath in os.listdir(tmp_folder):
+        assert not osp.isdir(filepath)
 
 
 def test_keep_duplicate_filename(dicom_duplicate_filename):


### PR DESCRIPTION
Sometimes identified informations are visible in the folder names (inside archive for exemple). To avoid letting this kind of information stay after deidentification, we remove all the folder hierarchy during deidentification.

Furthermore, archive file (.zip for exemple) can be left inside a folder to deidentify. We update the anonymize function in order to also unzip these archive during deidentification step.